### PR TITLE
Ignore assoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@ expr : expr '+' expr # expr1
 Furthermore, this approach builds on the target for Java by adding the extractors to that target. As we can't alter the generated context classes after the fact, the `unapply` methods are defined in a similarly named class, but not the same class. The file with the extractor objects is called `GrammarNameParserPatterns.scala`. The extractors are named the same as the alternatives, so as with the example above the context `<rule.upper>Context` can be destructured with `<rule.upper>0` and `<rule.upper>1`.
 
 Finally it is important to note that currently we can't destructure arbitrary eBNF patterns in rule productions, but you will be warned of this fact.
+
+# Compiling
+
+How to use this fork, for example, to compile VerCors' Java grammar:
+
+1. Run `mvn install -DskipTests=true -f pom.xml`. This will compile the fork into a jar.
+2. Use the jar to compile the grammar: 
+```bash
+[user@pc ~/antlr4/tool/target]
+$ java -jar antlr4-4.8-2-SNAPSHOT-complete.jar -scala-extractor-objects -lib ~/vercors/parsers/lib/antlr4/  ~/vercors/parsers/src/main/antlr4/JavaParser.g4
+```

--- a/tool/src/org/antlr/v4/codegen/model/ExtractorsAlt.java
+++ b/tool/src/org/antlr/v4/codegen/model/ExtractorsAlt.java
@@ -348,6 +348,12 @@ public class ExtractorsAlt extends OutputModelObject {
 			}
 
 			Tree tree = (Tree) child;
+
+			// Ignore settings like "<assoc=right>"
+			if (tree.getType() == ANTLRParser.ELEMENT_OPTIONS) {
+				continue;
+			}
+
 			MiniGrammar grammar = getMiniGrammar(tree);
 			if(grammar == null) {
 				return null;

--- a/tool/src/org/antlr/v4/codegen/model/ExtractorsAlt.java
+++ b/tool/src/org/antlr/v4/codegen/model/ExtractorsAlt.java
@@ -4,6 +4,7 @@ import org.antlr.runtime.tree.Tree;
 import org.antlr.v4.codegen.OutputModelFactory;
 import org.antlr.v4.misc.Utils;
 import org.antlr.v4.parse.ANTLRParser;
+import org.antlr.v4.parse.ToolANTLRParser;
 import org.antlr.v4.tool.ast.*;
 
 import java.util.*;
@@ -339,6 +340,32 @@ public class ExtractorsAlt extends OutputModelObject {
 		this.text += "  }\n";
 	}
 
+	public static Map<String, String> extractElementOptions(Tree tree) {
+		if (tree.getType() != ANTLRParser.ELEMENT_OPTIONS) {
+			throw new IllegalArgumentException("Tree can only be of type ELEMENT_OPTIONS");
+		}
+
+		Map<String, String> opts = new HashMap<>();
+
+		for (int i = 0; i < tree.getChildCount(); i++) {
+			Tree child = tree.getChild(i);
+			if (child.getType() != ANTLRParser.ASSIGN) {
+				throw new IllegalArgumentException("Unexpected ELEMENT_OPTIONS structure");
+			}
+			if (child.getChildCount() != 2) {
+				throw new IllegalArgumentException("Unexpected ELEMENT_OPTIONS structure");
+			}
+
+			Tree key = child.getChild(0);
+			Tree value = child.getChild(1);
+
+			// Assuming that calling toString() on the key/value trees yields a readable/useable string also for complex values like multiline strings and integers.
+			opts.put(key.toString(), value.toString());
+		}
+
+		return opts;
+	}
+
 	public static ExtractorsAlt createFromAltAST(OutputModelFactory factory, AltAST ast, String label) {
 		List<MiniGrammar> parts = new ArrayList<>();
 
@@ -351,7 +378,12 @@ public class ExtractorsAlt extends OutputModelObject {
 
 			// Ignore settings like "<assoc=right>"
 			if (tree.getType() == ANTLRParser.ELEMENT_OPTIONS) {
-				continue;
+				Map<String, String> opts = extractElementOptions(tree);
+				if (opts.size() == 1 && opts.keySet().contains("assoc")) {
+					continue;
+				} else {
+					throw new IllegalArgumentException("Only grammar option allowed is assoc");
+				}
 			}
 
 			MiniGrammar grammar = getMiniGrammar(tree);


### PR DESCRIPTION
Adds a check that skips AST elements that are element options, such as `<assoc=right>`. Currently only assoc is skipped, as we encounter more options that are compatible with scala code generation we can add them.